### PR TITLE
Missing apt-get commands for fresh installs

### DIFF
--- a/ansible/localhost/base/tasks/main.yml
+++ b/ansible/localhost/base/tasks/main.yml
@@ -28,6 +28,8 @@
         - ssl-cert
         - libexpat1
         - libapache2-mod-wsgi
+        - python-numpy
+        - python-scipy
 
     - name: Check NTP service to make sure it's running
       service: name=ntp state=started enabled=yes


### PR DESCRIPTION
Missed checking these in due to running provision on local box instead of vagrant destroy/up.  Needed for fresh deploys/builds.
