### PR TITLE
Bug fix for string.  (500 error for Xref tables)

### DIFF
--- a/holocron_api/api/models/standard.py
+++ b/holocron_api/api/models/standard.py
@@ -125,4 +125,4 @@ class Placement(models.Model):
     objects = DataFrameManager()
 
     def __str__(self):
-        return self.placement_id
+        return str(self.placement_id)


### PR DESCRIPTION
1 line fix to stop 500 errors in Xref tables.  Made the primary key a readable string for display.
